### PR TITLE
Write TwoWheelDrive drive layer

### DIFF
--- a/layer/controls.py
+++ b/layer/controls.py
@@ -1,0 +1,10 @@
+from layer import Layer
+from layer import InputGenerator
+
+
+class GamepadInputGenerator(InputGenerator):
+    pass
+
+
+class TankDriveControls(Layer):
+    pass

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -1,0 +1,80 @@
+from actuators import Motor
+from layer import Layer
+from math import copysign
+from mechanisms import Wheel
+from task import AxialMovementTask
+from task import TankDriveTask
+from task import TurnTask
+from task import UnsupportedTaskError
+from unit import convert
+
+
+class TwoWheelDrive(Layer):
+    """Drive layer for a two-wheel drive robot."""
+
+    """The id of the drive motor controller."""
+    _drive_koalabear = "6_spamandeggs"
+    """The number of encoder ticks per rotation of the drive motor shafts."""
+    _ticks_per_rot = 888
+    """The radius of the wheels in meters."""
+    _wheel_radius = 0.42
+    """The effective gear ratio of the wheels to the drive motor shafts.
+
+    Expressed as wheel_teeth / hub_gear_teeth.
+    """
+    _gear_ratio = 1
+    """Half the distance between the two driving wheels in meters."""
+    _wheel_span_radius = 0.84
+
+    def __init__(self, init_info):
+        self._left_wheel = Wheel(
+            Motor(init_info.get_robot(), self._drive_koalabear, "a/b")
+                .set_invert(False)
+                .set_pid(None, None, None),
+            self._wheel_radius,
+            self._ticks_per_rot)
+        self._right_wheel = Wheel(
+            Motor(init_info.get_robot(), self._drive_koalabear, "a/b")
+                .set_invert(False)
+                .set_pid(None, None, None),
+            self._wheel_radius,
+            self._ticks_per_rot)
+        self._left_start_pos = 0
+        self._right_start_pos = 0
+        self._left_goal_delta = 0
+        self._right_goal_delta = 0
+
+    def is_task_done(self):
+        left_done = ((self._left_wheel.get_distance() - self._left_start_pos < 0)
+            == (self._left_goal_delta < 0)) or self._left_goal_delta == 0
+        right_done = ((self._right_wheel.get_distance() - self._right_start_pos < 0)
+            == (self._right_goal_delta < 0)) or self._right_goal_delta == 0
+        done = left_done and right_done
+        if done:
+            self._left_wheel.set_velocity(0)
+            self._right_wheel.set_velocity(0)
+        return done
+
+    def update(self):
+        pass # Adaptive velocity control goes here
+
+    def accept_task(self, task):
+        self._left_start_pos = self._left_wheel.get_distance()
+        self._right_start_pos = self._right_wheel.get_distance()
+        if isinstance(task, AxialMovementTask):
+            self._left_goal_delta = task.distance
+            self._right_goal_delta = task.distance
+        elif isinstance(task, TurnMovementTask):
+            self._left_goal_delta = -task.angle * self._wheel_span_radius * self._gear_ratio
+            self._right_goal_delta = task.angle * self._wheel_span_radius * self._gear_ratio
+        elif isinstance(task, TankDriveTask):
+            self._left_goal_delta = 0
+            self._right_goal_delta = 0
+            # Clamp to 1 to prevent upscaling:
+            max_abs_power = max(abs(task.left), abs(task.right), 1)
+            self._left_wheel.set_velocity(task.left / max_abs_power)
+            self._right_wheel.set_velocity(task.right / max_abs_power)
+        else:
+            raise UnsupportedTaskError(self, task)
+        self._left_wheel.set_velocity(copysign(1, self._left_goal_delta))
+        self._right_wheel.set_velocity(copysign(1, self._right_goal_delta))

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -6,7 +6,7 @@ from task import AxialMovementTask
 from task import TankDriveTask
 from task import TurnTask
 from task import UnsupportedTaskError
-from unit import convert
+from units import convert
 
 
 class TwoWheelDrive(Layer):
@@ -38,13 +38,13 @@ class TwoWheelDrive(Layer):
         # might have remembered state from a different drive layer if it hasn't been power cycled
         # since then
         self._left_wheel = Wheel(
-            Motor(init_info.get_robot(), self._drive_koalabear, "a/b")
+            Motor(init_info.get_robot(), self._drive_koalabear, "a")
                 .set_invert(False)
                 .set_pid(None, None, None),
             self._wheel_radius,
             self._ticks_per_rot)
         self._right_wheel = Wheel(
-            Motor(init_info.get_robot(), self._drive_koalabear, "a/b")
+            Motor(init_info.get_robot(), self._drive_koalabear, "b")
                 .set_invert(False)
                 .set_pid(None, None, None),
             self._wheel_radius,
@@ -83,7 +83,7 @@ class TwoWheelDrive(Layer):
         if isinstance(task, AxialMovementTask):
             self._left_goal_delta = task.distance
             self._right_goal_delta = task.distance
-        elif isinstance(task, TurnMovementTask):
+        elif isinstance(task, TurnTask):
             # "Effective" as in "multiplied by all the weird constants we need"
             effective_radius = self._wheel_span_radius * self._gear_ratio * self._slipping_constant
             self._left_goal_delta = -task.angle * effective_radius

--- a/layer/strategy.py
+++ b/layer/strategy.py
@@ -91,3 +91,23 @@ class SafeStrategy(Layer):
 
     def accept_task(self, task):
         raise UnsupportedTaskError(self, task)
+
+
+class SimpleDriveTest(Layer):
+    """Drives in a square indefinitely."""
+
+    def __init__(self, init_info):
+        self._straight = False # Inverted before first update
+
+    def is_task_done(self):
+        return False
+
+    def update(self):
+        self._straight = not self._straight
+        if self._straight:
+            return AxialMovementTask(convert(1, "m", "m"))
+        else:
+            return TurnTask(convert(-0.25, "rev", "rad"))
+
+    def accept_task(self, task):
+        raise UnsupportedTaskError(self, task)

--- a/layer/strategy.py
+++ b/layer/strategy.py
@@ -1,8 +1,9 @@
 from layer import Layer
 from layer import QueuedLayer
 from units import convert
-from task import UnsupportedTaskError
 from task import AxialMovementTask
+from task import TurnTask
+from task import UnsupportedTaskError
 
 class CubeDropStrategy(QueuedLayer):
     """Ambitious autonomous strategy for maximum points.

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
-#from layer.drive import TwoWheelDrive
-#from layer import SimpleDriveTest
-#from layer.controls import TankDriveControls
-#from layer.controls import GamepadInputGenerator
 from controller import RobotController
+from layer.controls import GamepadInputGenerator
+from layer.controls import TankDriveControls
+from layer.drive import TwoWheelDrive
+from layer.strategy import CubeDropStrategy
+from layer.strategy import CubePlateStrategy
+from layer.strategy import SafeStrategy
+from layer.strategy import SimpleDriveTest
 from mock_robot import MockRobot
 
 try:
@@ -10,21 +13,19 @@ try:
     is_dawn = True
 except NameError:
     robot = MockRobot({
-        "koalabear": 0,
+        "koalabear": 2,
         "servocontroller": 0,
     })
     is_dawn = False
+
 auto_layer_classes = [
-#    TwoWheelDrive,
-#    SimpleDriveTest,
-    RestaurantPrinter,
-    RestaurantSectionLayer,
-    RestaurantMenuSource,
+    TwoWheelDrive,
+    SimpleDriveTest,
 ]
 teleop_layer_classes = [
-#    TwoWheelDrive,
-#    TankDriveControls,
-#    GamepadInputGenerator,
+    TwoWheelDrive,
+    TankDriveControls,
+    GamepadInputGenerator,
 ]
 robot_controller = RobotController(robot)
 

--- a/mock_robot.py
+++ b/mock_robot.py
@@ -73,9 +73,8 @@ class MockRobot:
         if not device_id in self._devices:
             for device_type, default_props in self._default_device_properties.items():
                 if value_name in default_props:
-                    found_device_type = True
-                    break
-            if not found_device_type:
+                    break # Skips for-else clause
+            else:
                 raise ValueError(f"Unrecognized device property {value_name}.")
             if not device_type in self._max_devices or (self._device_counts[device_type] >= self._max_devices[device_type]):
                 raise ValueError(f"Cannot initialize more devices of type {device_type}. Check the id for typos.")

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -158,8 +158,8 @@ def process_file(file_path, indent=" " * 4, module_name=None, module_list=None, 
                 f"{indent * 4}if not translation_result:",
                 f"{indent * 5}tb = tb.tb_next",
                 f"{indent * 5}continue",
-                f"{indent * 4}module_name, line_no = translation_result",
-                f"{indent * 4}frame_lines.append(f'  File \"{{module_name + \".py\"}}\", line {{line_no}}, in {{tb.tb_frame.f_code.co_name}}')",
+                f"{indent * 4}module_path, line_no = translation_result",
+                f"{indent * 4}frame_lines.append(f'  File \"{{module_path}}\", line {{line_no}}, in {{tb.tb_frame.f_code.co_name}}')",
                 f"{indent * 4}tb = tb.tb_next",
                 f"{indent * 3}print('\\n'.join(frame_lines))",
                 f"{indent * 3}print(type(e).__name__ + (': ' if str(e) else '') + str(e))",
@@ -173,7 +173,7 @@ def process_file(file_path, indent=" " * 4, module_name=None, module_list=None, 
             for module in module_list:
                 module_line_entries.append(
                     f"{indent}elif line_no >= {running_line_num}:\n"
-                    f"{indent * 2}return '{module.name}', line_no - {running_line_num + 5}\n"
+                    f"{indent * 2}return '{module.file_path}', line_no - {running_line_num + 5}\n"
                 )
                 running_line_num += module.body_text.count("\n")
             module_line_entries.append(

--- a/task.py
+++ b/task.py
@@ -29,3 +29,20 @@ class TurnTask:
     Negative values indicate clockwise turns.
     """
     angle: float
+
+
+@dataclass
+class TankDriveTask:
+    """Specifies relative accelerations for left and right side of the robot.
+
+    Despite the name, not necessarily produced by tank drive controls."""
+
+    """The relative acceleration to apply to the left side of the robot.
+
+    Positive values indicate forward movement and negative values indicate backward."""
+    left: float
+
+    """The relative acceleration to apply to the right side of the robot.
+
+    Positive values indicate forward movement and negative values indicate backward."""
+    right: float

--- a/units.py
+++ b/units.py
@@ -8,7 +8,7 @@ units_per_m = {
 }
 units_per_rad = {
     "deg": 180 / pi,
-    "rev": 1 / 2 / pi
+    "rev": 1 / 2 / pi,
     "rad": 1,
 }
 valid_units = set(units_per_rad.keys()) | set(units_per_m.keys())


### PR DESCRIPTION
- **Add SimpleDriveTest**
  Drives in a square, forever. "One must imagine the robot happy. The struggle itself toward the pressure plates is enough to fill a metal heart."
- **Add TwoWheelDrive**
  Main drive layer that will be used this season, unless we suddenly get donated a zillion panda points and can afford mecanum wheels.
- **Add slipping constant and more comments**
  Add in a slipping constant for us to introduce weird factors to when the encoder math inevitably does The Wrong Thing. Also documentation. Yum.
- **Fix small syntax errors, add stub controls.py**
  Pass syntax checks by fixing errors and adding a stub controls module.
- **Use module path in enhanced preprocessor errmsg**
  Use the module file paths that we now collect in the preprocessor instead of just the module name when printing enhanced error messages.
